### PR TITLE
Count raw bytes as they're read

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,26 +6,52 @@ mod manifest;
 use crate::manifest::Manifest;
 use anyhow::Context;
 use get_size::GetSize;
-use std::io::Read;
+use std::io::{self, BufReader, Read};
 use thousands::Separable;
 
 fn main() -> anyhow::Result<()> {
     let Some(url) = std::env::args().nth(1) else {
         anyhow::bail!("No URL argument supplied");
     };
-    let mut r = ureq::get(&url)
-        .call()
-        .context("GET request failed")?
-        .into_reader();
-    let mut body = Vec::new();
-    r.read_to_end(&mut body)
-        .context("failed to read response body")?;
-    let body_len_str = body.len().separate_with_spaces();
-    let parsed =
-        serde_json::from_slice::<Manifest>(&body).context("failed to deserialize response")?;
+    let mut counter = CountingReader::new(
+        ureq::get(&url)
+            .call()
+            .context("GET request failed")?
+            .into_reader(),
+    );
+    let parsed = serde_json::from_reader::<_, Manifest>(BufReader::new(&mut counter))
+        .context("failed to deserialize response")?;
+    let body_len_str = counter.bytes_read().separate_with_spaces();
     let parsed_size_str = parsed.get_size().separate_with_spaces();
     let width = body_len_str.len().max(parsed_size_str.len());
     println!("Raw    response: {body_len_str:>width$} bytes");
     println!("Parsed response: {parsed_size_str:>width$} bytes");
     Ok(())
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct CountingReader<R> {
+    inner: R,
+    bytes_read: usize,
+}
+
+impl<R> CountingReader<R> {
+    fn new(inner: R) -> Self {
+        CountingReader {
+            inner,
+            bytes_read: 0,
+        }
+    }
+
+    fn bytes_read(&self) -> usize {
+        self.bytes_read
+    }
+}
+
+impl<R: Read> Read for CountingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let qty = self.inner.read(buf)?;
+        self.bytes_read += qty;
+        Ok(qty)
+    }
 }


### PR DESCRIPTION
Unfortunately, this markedly increases the runtime of the code.

---

This is an historical PR kept around to remind me why this strategy doesn't work.